### PR TITLE
build: Update PyO3 to latest version - 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dyn-clone = "1.0"
 log = "0.4"
 lazy_static = "1.5"
 ctrlc = { version = "3.5.2", optional = true }
-pyo3 = { version = "0.28", optional = true }
+pyo3 = { version = "0.29", optional = true }
 # The "always_use_statm" feature should prioritize speed over accuracy.
 memory-stats = { version = "1.2", optional = true, features = ["always_use_statm"] }
 


### PR DESCRIPTION
PyO3 0.29 fixes a number of RustSec issues.

Update was trivial - all tests pass.

Fixes #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to maintain compatibility and support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->